### PR TITLE
Removed overly complicated regex to parse a date field

### DIFF
--- a/Clean-Usbdeview.ps1
+++ b/Clean-Usbdeview.ps1
@@ -150,9 +150,8 @@ if ($RemoveNoDriver) {
 if (($OldestDate -ne $null) -or ($NewestDate -ne $null)) {
 
     $removeDevices | ForEach-Object { 
-    
-            $_.'Last Plug/Unplug Date' -match "(?<Month>\d{1,2})/(?<Day>\d{1,2})/(?<Year>\d{4})" | Out-Null
-            $_.'Last Plug/Unplug Date' = [datetime]"$($Matches.Month)/$($Matches.Day)/$($Matches.Year)"
+            
+            $_.'Last Plug/Unplug Date' = [datetime]$_.'Last Plug/Unplug Date'
         }
 
     # filter records that are older than a user specified date


### PR DESCRIPTION
I used a regex to parse a date field but realized that simply casting it to a datetime object would achieve the same result in a much simpler fashion.  It also preserved the time portion too which I was ignoring with the regex.